### PR TITLE
Run tests and identify failing ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 coverage
 .turbo
 .npmrc
+package-lock.json
 
 # VitePress cache
 docs/.vitepress/cache

--- a/packages/core/src/expressions/variable-resolver.ts
+++ b/packages/core/src/expressions/variable-resolver.ts
@@ -44,9 +44,9 @@ function resolveNestedPath(path: string, obj: any): any {
   let current = obj;
 
   for (const part of parts) {
-    // if (current === null || current === undefined) {
-    //   return undefined;
-    // }
+    if (current === null || current === undefined) {
+      return undefined;
+    }
     current = current[part];
   }
 


### PR DESCRIPTION
Fixes test failure in variable-resolver.test.ts where accessing nested properties on undefined values was causing TypeError. The check was previously commented out, causing the resolver to crash when trying to access properties like 'user.name' when 'user' is undefined.

Also adds package-lock.json to .gitignore since project uses pnpm.

Test results: All 63 tests passing