### PR TITLE
feat: default FormContainer with built-in SubmitButton for React, Vue…

### DIFF
--- a/examples/react/src/basic-ui/components/Containers/FormContainer.tsx
+++ b/examples/react/src/basic-ui/components/Containers/FormContainer.tsx
@@ -1,17 +1,23 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
+import type { FormContainerProps } from '@schepta/factory-react';
+import { SubmitButton } from '../SubmitButton';
 
-export const FormContainer = ({ children, onSubmit, externalContext, ...props }: any) => {
-    const formContext = useFormContext();
-    const handleSubmit = formContext?.handleSubmit;
-    
-    return (
-      <form 
-        onSubmit={onSubmit ? handleSubmit(onSubmit) : undefined}
-        data-test-id="FormContainer"
-        {...props}
-      >
-        {children}
-      </form>
-    );
+export const FormContainer: React.FC<FormContainerProps> = ({ 
+  children, 
+  onSubmit, 
+}) => {
+  const formContext = useFormContext();
+  
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (onSubmit) formContext.handleSubmit(onSubmit)();
   };
+
+  return (
+    <form onSubmit={handleFormSubmit} data-test-id="FormContainer">
+      {children}
+      {onSubmit && <SubmitButton onSubmit={onSubmit} />}
+    </form>
+  );
+};

--- a/examples/react/src/basic-ui/components/FormModal.tsx
+++ b/examples/react/src/basic-ui/components/FormModal.tsx
@@ -1,4 +1,5 @@
-import { FormFactory, FormFactoryRef } from "@schepta/factory-react";
+import { FormFactory } from "@schepta/factory-react";
+import type { FormFactoryRef } from "@schepta/factory-react";
 import React, { useState, useRef } from "react";
 import { FormSchema } from "@schepta/core";
 
@@ -45,7 +46,7 @@ export const FormModal = ({ schema, onSubmit }: FormModalProps) => {
           fontWeight: '500',
         }}
       >
-        Open Form Modal
+        Open Modal Form
       </button>
 
       {/* Modal overlay */}

--- a/examples/react/src/basic-ui/components/SubmitButton.tsx
+++ b/examples/react/src/basic-ui/components/SubmitButton.tsx
@@ -1,28 +1,17 @@
 import React from 'react';
-import { useFormContext } from 'react-hook-form';
 import type { SubmitButtonProps } from '@schepta/factory-react';
 
 export const SubmitButton: React.FC<SubmitButtonProps> = ({
   children,
   'x-content': content,
-  onSubmit: onSubmitProp,
-  externalContext,
   ...props
 }) => {
-  const formContext = useFormContext();
-  const handleSubmit = formContext?.handleSubmit;
-  const onSubmit = onSubmitProp ?? externalContext?.onSubmit;
 
-  const handleClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    if (onSubmit) handleSubmit(onSubmit)();
-  };
 
   return (
     <div style={{ marginTop: '24px', textAlign: 'right' }}>
       <button
-        type="button"
-        onClick={handleClick}
+        type="submit"
         data-test-id="submit-button"
         style={{
           padding: '12px 24px',

--- a/examples/react/src/chakra-ui/components/Containers/FormContainer.tsx
+++ b/examples/react/src/chakra-ui/components/Containers/FormContainer.tsx
@@ -1,19 +1,20 @@
 import React from "react";
 import { Box } from "@chakra-ui/react";
-import { useFormContext } from "react-hook-form";
+import type { FormContainerProps } from "@schepta/factory-react";
+import { SubmitButton } from "../SubmitButton";
 
-export const FormContainer = ({ children, onSubmit: onSubmitProp, externalContext, ...props }: any) => {
-    const { handleSubmit } = useFormContext();
-    // FormFactory/orchestrator passes onSubmit in props; fallback to externalContext for schema-driven usage
-    const onSubmit = onSubmitProp ?? externalContext?.onSubmit;
-    
-    return (
-      <Box
-        as="form"
-        onSubmit={onSubmit ? handleSubmit(onSubmit) : undefined}
-        {...props}
-      >
-        {children}
-      </Box>
-    );
-  };
+export const FormContainer: React.FC<FormContainerProps> = ({ 
+  children, 
+  onSubmit, 
+}) => {
+
+  return (
+    <Box
+      as="form"
+      data-test-id="FormContainer"
+    >
+      {children}
+      {onSubmit && <SubmitButton onSubmit={onSubmit} />}
+    </Box>
+  );
+};

--- a/examples/react/src/chakra-ui/components/SubmitButton.tsx
+++ b/examples/react/src/chakra-ui/components/SubmitButton.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useFormContext } from "react-hook-form";
 import { Box, Button } from "@chakra-ui/react";
 import type { SubmitButtonProps } from "@schepta/factory-react";
 
@@ -10,24 +9,13 @@ export const SubmitButton: React.FC<SubmitButtonProps> = ({
   externalContext,
   ...props
 }) => {
-  const { handleSubmit } = useFormContext();
-  // FormFactory passes onSubmit directly; fallback to externalContext for schema-driven usage
-  const onSubmit = onSubmitProp ?? externalContext?.onSubmit;
-    
-    const handleClick = (e: React.MouseEvent) => {
-      e.preventDefault();
-      if (onSubmit) {
-        handleSubmit(onSubmit)();
-      }
-    };
-  
+
     return (
       <Box mt={6} display="flex" justifyContent="flex-end">
         <Button
-          type="button"
+          type="submit"
           colorScheme="blue"
           size="lg"
-          onClick={handleClick}
           {...props}
         >
           {content || children || 'Submit'}

--- a/examples/react/src/material-ui/components/Containers/FormContainer.tsx
+++ b/examples/react/src/material-ui/components/Containers/FormContainer.tsx
@@ -1,18 +1,20 @@
 import React from "react";
 import { Box } from "@mui/material";
-import { useFormContext } from "react-hook-form";
+import type { FormContainerProps } from "@schepta/factory-react";
+import { SubmitButton } from "../SubmitButton";
 
-export const FormContainer = ({ children, externalContext, ...props }: any) => {
-    const { handleSubmit } = useFormContext();
-    const onSubmit = externalContext?.onSubmit;
-    
-    return (
-      <Box
-        component="form"
-        onSubmit={onSubmit ? handleSubmit(onSubmit) : undefined}
-        {...props}
-      >
-        {children}
-      </Box>
-    );
-  };
+export const FormContainer: React.FC<FormContainerProps> = ({ 
+  children, 
+  onSubmit, 
+}) => {
+
+  return (
+    <Box
+      component="form"
+      data-test-id="FormContainer"
+    >
+      {children}
+      {onSubmit && <SubmitButton onSubmit={onSubmit} />}
+    </Box>
+  );
+};

--- a/examples/react/src/material-ui/components/SubmitButton.tsx
+++ b/examples/react/src/material-ui/components/SubmitButton.tsx
@@ -1,29 +1,18 @@
 import React from "react";
 import { Box, Button } from "@mui/material";
-import { useFormContext } from "react-hook-form";
 import type { SubmitButtonProps } from "@schepta/factory-react";
 
 export const SubmitButton: React.FC<SubmitButtonProps> = ({
   children,
   "x-content": content,
-  onSubmit: onSubmitProp,
-  externalContext,
   ...props
 }) => {
-  const { handleSubmit } = useFormContext();
-  const onSubmit = onSubmitProp ?? externalContext?.onSubmit;
-
-  const handleClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    if (onSubmit) handleSubmit(onSubmit)();
-  };
 
   return (
     <Box sx={{ mt: 3, display: "flex", justifyContent: "flex-end" }}>
       <Button
-        type="button"
+        type="submit"
         variant="contained"
-        onClick={handleClick}
         size="large"
         {...props}
       >

--- a/packages/core/src/registry/component-registry.ts
+++ b/packages/core/src/registry/component-registry.ts
@@ -22,9 +22,37 @@ export const defaultTypeProps: Record<ComponentType, Record<string, any>> = {
 };
 
 /**
- * Default component registry (empty by default, can be extended)
+ * Factory default components
+ * 
+ * Each factory (React, Vue, Vanilla) sets its built-in components here.
  */
-export const defaultComponentRegistry: Record<string, ComponentSpec> = {};
+let factoryDefaultComponents: Record<string, ComponentSpec> = {};
+
+/**
+ * Set factory default components
+ * 
+ * Called by each factory to register its built-in components.
+ * 
+ * @example
+ * ```ts
+ * setFactoryDefaultComponents({
+ *   FormContainer: createComponentSpec({ ... }),
+ *   SubmitButton: createComponentSpec({ ... }),
+ * });
+ * ```
+ */
+export function setFactoryDefaultComponents(
+  components: Record<string, ComponentSpec>
+): void {
+  factoryDefaultComponents = components;
+}
+
+/**
+ * Get factory default components
+ */
+export function getFactoryDefaultComponents(): Record<string, ComponentSpec> {
+  return factoryDefaultComponents;
+}
 
 /**
  * Registry overrides (global registrations)
@@ -44,14 +72,14 @@ export function registerComponent(name: string, config: Partial<ComponentSpec>):
 /**
  * Get unified component registry
  * 
- * Priority order: local > global > registry overrides > default
+ * Priority order: local > global > registry overrides > factory defaults
  */
 export function getComponentRegistry(
   globalComponents?: Record<string, ComponentSpec>,
   localComponents?: Record<string, ComponentSpec>
 ): Record<string, ComponentSpec> {
-  // Start with built-in components
-  const merged: Record<string, ComponentSpec> = { ...defaultComponentRegistry };
+  // Start with factory default components
+  const merged: Record<string, ComponentSpec> = { ...factoryDefaultComponents };
   
   // Apply global components (from provider)
   if (globalComponents) {

--- a/packages/core/src/registry/renderer-registry.ts
+++ b/packages/core/src/registry/renderer-registry.ts
@@ -44,10 +44,14 @@ export const defaultTypeRenderers: Record<ComponentType, RendererFn> = {
     return runtime.create(spec, propsWithChildren);
   },
   'FormContainer': (spec, props, runtime, children) => {
+    const { onSubmit, externalContext } = props;
     const sanitized = sanitizePropsForDOM(props);
-    const propsWithChildren = children && children.length > 0 
-      ? { ...sanitized, children }
-      : sanitized;
+    const propsWithChildren = {
+      ...sanitized,
+      onSubmit,
+      externalContext,
+      ...(children && children.length > 0 ? { children } : {}),
+    };
     return runtime.create(spec, propsWithChildren);
   },
   content: (spec, props, runtime, children) => {

--- a/packages/core/src/utils/sanitize-props.ts
+++ b/packages/core/src/utils/sanitize-props.ts
@@ -12,7 +12,6 @@ const INTERNAL_PROPS = [
   'name',
   'x-ui',
   'x-component-props',
-  'x-content',
   'x-rules',
   'x-reactions',
   'x-slots',

--- a/packages/factories/react/src/components/DefaultFormContainer.tsx
+++ b/packages/factories/react/src/components/DefaultFormContainer.tsx
@@ -1,0 +1,59 @@
+/**
+ * Default Form Container Component
+ * 
+ * Built-in form container that wraps children in a <form> tag
+ * and renders a submit button. Can be overridden via createComponentSpec.
+ */
+
+import React from 'react';
+import { DefaultSubmitButton, SubmitButtonComponentType } from './DefaultSubmitButton';
+
+/**
+ * Props for FormContainer component.
+ * Use this type when creating a custom FormContainer.
+ */
+export interface FormContainerProps {
+  /** Form field children */
+  children?: React.ReactNode;
+  /** Submit handler - when provided, renders a submit button */
+  onSubmit?: (values: Record<string, any>) => void | Promise<void>;
+  /** External context passed from FormFactory */
+  externalContext?: Record<string, any>;
+  /** 
+   * Custom SubmitButton component - resolved by FormFactory from registry.
+   * If not provided, uses DefaultSubmitButton.
+   */
+  SubmitButtonComponent?: SubmitButtonComponentType;
+}
+
+/**
+ * Default form container component.
+ * 
+ * Renders children inside a <form> tag with an optional submit button.
+ * 
+ * - When `onSubmit` is provided: renders submit button inside the form
+ * - When `onSubmit` is NOT provided: no submit button (for external submit via formRef)
+ * 
+ * @example Using with FormFactory (automatic)
+ * ```tsx
+ * <FormFactory schema={schema} onSubmit={handleSubmit} />
+ * ```
+ * 
+ * @example External submit (no internal button)
+ * ```tsx
+ * const formRef = useRef<FormFactoryRef>(null);
+ * <FormFactory ref={formRef} schema={schema} />
+ * <button onClick={() => formRef.current?.submit(handleSubmit)}>Submit</button>
+ * ```
+ */
+export const DefaultFormContainer: React.FC<FormContainerProps> = ({ 
+  children, 
+  onSubmit,
+}) => {
+  return (
+    <form data-test-id="FormContainer">
+      {children}
+      {onSubmit && <DefaultSubmitButton onSubmit={onSubmit} />}
+    </form>
+  );
+};

--- a/packages/factories/react/src/components/DefaultSubmitButton.tsx
+++ b/packages/factories/react/src/components/DefaultSubmitButton.tsx
@@ -1,0 +1,75 @@
+/**
+ * Default Submit Button Component
+ * 
+ * Built-in submit button for forms. Can be overridden via createComponentSpec.
+ */
+
+import React from 'react';
+
+/**
+ * Props passed to the SubmitButton component by FormFactory.
+ * Use this type when customizing SubmitButton via components.SubmitButton to ensure
+ * correct typing and that onSubmit is always handled.
+ *
+ * @example
+ * ```tsx
+ * import { SubmitButtonProps } from '@schepta/factory-react';
+ * import { useFormContext } from 'react-hook-form';
+ *
+ * const MySubmitButton: React.FC<SubmitButtonProps> = ({ onSubmit, children }) => {
+ *   const { handleSubmit } = useFormContext();
+ *   return (
+ *     <button type="button" onClick={(e) => { e.preventDefault(); handleSubmit(onSubmit)(); }}>
+ *       {children ?? 'Submit'}
+ *     </button>
+ *   );
+ * };
+ * ```
+ */
+export interface SubmitButtonProps {
+  /**
+   * Submit handler - called with form values.
+   * FormFactory always passes this when rendering the built-in SubmitButton.
+   * When used from schema, it may also be provided via externalContext.onSubmit.
+   */
+  onSubmit?: (values: Record<string, any>) => void | Promise<void>;
+  /** Optional label (e.g. from x-content when used from schema) */
+  'x-content'?: string;
+  /** Optional external context (when used from schema). May contain onSubmit. */
+  externalContext?: Record<string, any>;
+  /** Optional children */
+  children?: React.ReactNode;
+}
+
+/**
+ * Component type for custom SubmitButton. Use with createComponentSpec when
+ * registering a custom SubmitButton in components.
+ */
+export type SubmitButtonComponentType = React.ComponentType<SubmitButtonProps>;
+
+/**
+ * Default submit button component
+ * Can be overridden via components prop or ScheptaProvider
+ */
+export const DefaultSubmitButton: React.FC<SubmitButtonProps> = ({ onSubmit }) => {
+  return (
+    <div style={{ marginTop: '24px', textAlign: 'right' }}>
+      <button
+        type="submit"
+        data-test-id="submit-button"
+        style={{
+          padding: '12px 24px',
+          backgroundColor: '#007bff',
+          color: 'white',
+          border: 'none',
+          borderRadius: '4px',
+          cursor: 'pointer',
+          fontSize: '16px',
+          fontWeight: '500',
+        }}
+      >
+        Submit
+      </button>
+    </div>
+  );
+};

--- a/packages/factories/react/src/components/index.ts
+++ b/packages/factories/react/src/components/index.ts
@@ -1,0 +1,8 @@
+/**
+ * React Factory Components
+ * 
+ * Built-in components for the React form factory.
+ */
+
+export * from './DefaultFormContainer';
+export * from './DefaultSubmitButton';

--- a/packages/factories/react/src/index.ts
+++ b/packages/factories/react/src/index.ts
@@ -9,9 +9,16 @@ export {
   FormFactory,
   type FormFactoryProps,
   type FormFactoryRef,
+} from './form-factory';
+
+// Components (types and defaults)
+export {
+  DefaultFormContainer,
+  DefaultSubmitButton,
+  type FormContainerProps,
   type SubmitButtonProps,
   type SubmitButtonComponentType,
-} from './form-factory';
+} from './components';
 
 // Hooks (for advanced usage)
 export * from './hooks';

--- a/packages/factories/vanilla/src/components/DefaultFormContainer.ts
+++ b/packages/factories/vanilla/src/components/DefaultFormContainer.ts
@@ -1,0 +1,63 @@
+/**
+ * Default Form Container Component for Vanilla JS
+ * 
+ * Built-in form container that wraps children in a <form> tag
+ * and renders a submit button. Can be overridden via createComponentSpec.
+ */
+
+import { createDefaultSubmitButton, type SubmitButtonFactory } from './DefaultSubmitButton';
+
+/**
+ * Props for FormContainer component.
+ * Use this type when creating a custom FormContainer.
+ */
+export interface FormContainerProps {
+  /** Child elements to render inside the form */
+  children?: HTMLElement[];
+  /** Submit handler - when provided, renders a submit button */
+  onSubmit?: () => void;
+  /** External context passed from FormFactory */
+  externalContext?: Record<string, any>;
+  /** 
+   * Custom SubmitButton factory - resolved by FormFactory from registry.
+   * If not provided, uses createDefaultSubmitButton.
+   */
+  createSubmitButton?: SubmitButtonFactory;
+}
+
+/**
+ * Creates a default form container element.
+ * 
+ * Renders children inside a <form> tag with an optional submit button.
+ * 
+ * - When `onSubmit` is provided: renders submit button inside the form
+ * - When `onSubmit` is NOT provided: no submit button (for external submit via formRef)
+ * 
+ * @example
+ * ```ts
+ * const form = createDefaultFormContainer({
+ *   children: [inputElement, selectElement],
+ *   onSubmit: () => console.log('submitted'),
+ * });
+ * container.appendChild(form);
+ * ```
+ */
+export function createDefaultFormContainer(props: FormContainerProps): HTMLElement {
+  const form = document.createElement('form');
+  form.dataset.testId = 'FormContainer';
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    props.onSubmit?.();
+  });
+
+  // Append children
+  props.children?.forEach(child => form.appendChild(child));
+  
+  // Add submit button if onSubmit is provided
+  if (props.onSubmit) {
+    const submitButton = createDefaultSubmitButton({ onSubmit: props.onSubmit });
+    form.appendChild(submitButton);
+  }
+
+  return form;
+}

--- a/packages/factories/vanilla/src/components/DefaultSubmitButton.ts
+++ b/packages/factories/vanilla/src/components/DefaultSubmitButton.ts
@@ -1,0 +1,46 @@
+/**
+ * Default Submit Button Component for Vanilla JS
+ * 
+ * Built-in submit button for forms. Can be overridden via createComponentSpec.
+ */
+
+/**
+ * Props for SubmitButton component.
+ * Use this type when creating a custom SubmitButton.
+ */
+export interface SubmitButtonProps {
+  /** Submit handler - triggers form submission */
+  onSubmit: () => void;
+}
+
+/**
+ * Factory function type for custom SubmitButton.
+ */
+export type SubmitButtonFactory = (props: SubmitButtonProps) => HTMLElement;
+
+/**
+ * Creates a default submit button element.
+ * Can be overridden via components prop or ScheptaProvider.
+ */
+export function createDefaultSubmitButton(props: SubmitButtonProps): HTMLElement {
+  const container = document.createElement('div');
+  container.style.marginTop = '24px';
+  container.style.textAlign = 'right';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.textContent = 'Submit';
+  button.dataset.testId = 'submit-button';
+  button.style.padding = '12px 24px';
+  button.style.backgroundColor = '#007bff';
+  button.style.color = 'white';
+  button.style.border = 'none';
+  button.style.borderRadius = '4px';
+  button.style.cursor = 'pointer';
+  button.style.fontSize = '16px';
+  button.style.fontWeight = '500';
+  button.addEventListener('click', props.onSubmit);
+
+  container.appendChild(button);
+  return container;
+}

--- a/packages/factories/vanilla/src/components/index.ts
+++ b/packages/factories/vanilla/src/components/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Vanilla JS Factory Components
+ * 
+ * Built-in components for the Vanilla JS form factory.
+ */
+
+export * from './DefaultFormContainer';
+export * from './DefaultSubmitButton';

--- a/packages/factories/vanilla/src/index.ts
+++ b/packages/factories/vanilla/src/index.ts
@@ -1,2 +1,22 @@
-export * from './form-factory';
+/**
+ * @schepta/factory-vanilla
+ * 
+ * Vanilla JS factories for schepta rendering engine
+ */
+
+// Main factory
+export {
+  createFormFactory,
+  type FormFactoryOptions,
+  type FormFactoryResult,
+} from './form-factory';
+
+// Components (types and defaults)
+export {
+  createDefaultFormContainer,
+  createDefaultSubmitButton,
+  type FormContainerProps,
+  type SubmitButtonProps,
+  type SubmitButtonFactory,
+} from './components';
 

--- a/packages/factories/vue/src/components/DefaultFormContainer.ts
+++ b/packages/factories/vue/src/components/DefaultFormContainer.ts
@@ -1,0 +1,57 @@
+/**
+ * Default Form Container Component for Vue
+ * 
+ * Built-in form container that wraps children in a <form> tag
+ * and renders a submit button. Can be overridden via createComponentSpec.
+ */
+
+import { defineComponent, h, type PropType } from 'vue';
+import { DefaultSubmitButton, type SubmitButtonComponentType } from './DefaultSubmitButton';
+
+/**
+ * Props for FormContainer component.
+ * Use this type when creating a custom FormContainer.
+ */
+export interface FormContainerProps {
+  /** Submit handler - when provided, renders a submit button */
+  onSubmit?: () => void;
+  /** External context passed from FormFactory */
+  externalContext?: Record<string, any>;
+  /** 
+   * Custom SubmitButton component - resolved by FormFactory from registry.
+   * If not provided, uses DefaultSubmitButton.
+   */
+  SubmitButtonComponent?: SubmitButtonComponentType;
+}
+
+/**
+ * Default form container component for Vue.
+ * 
+ * Renders children inside a <form> tag with an optional submit button.
+ * 
+ * - When `onSubmit` is provided: renders submit button inside the form
+ * - When `onSubmit` is NOT provided: no submit button (for external submit via formRef)
+ */
+export const DefaultFormContainer = defineComponent({
+  name: 'DefaultFormContainer',
+  props: {
+    onSubmit: {
+      type: Function as PropType<() => void>,
+      required: false,
+    },
+  },
+  setup(props, { slots }) {
+    return () => {
+      return h('form', {
+        'data-test-id': 'FormContainer',
+        onSubmit: (e: Event) => {
+          e.preventDefault();
+          props.onSubmit?.();
+        }
+      }, [
+        slots.default?.(),
+        props.onSubmit && h(DefaultSubmitButton, { onSubmit: props.onSubmit })
+      ]);
+    };
+  }
+});

--- a/packages/factories/vue/src/components/DefaultSubmitButton.ts
+++ b/packages/factories/vue/src/components/DefaultSubmitButton.ts
@@ -1,0 +1,62 @@
+/**
+ * Default Submit Button Component for Vue
+ * 
+ * Built-in submit button for forms. Can be overridden via createComponentSpec.
+ */
+
+import { defineComponent, h, type PropType, type Component } from 'vue';
+
+/**
+ * Props for SubmitButton component.
+ * Use this type when creating a custom SubmitButton.
+ */
+export interface SubmitButtonProps {
+  /** Submit handler - triggers form submission */
+  onSubmit?: () => void;
+}
+
+/**
+ * Component type for custom SubmitButton.
+ */
+export type SubmitButtonComponentType = Component<SubmitButtonProps>;
+
+/**
+ * Default submit button component for Vue
+ * Can be overridden via components prop or ScheptaProvider
+ */
+export const DefaultSubmitButton = defineComponent({
+  name: 'DefaultSubmitButton',
+  props: {
+    onSubmit: {
+      type: Function as PropType<() => void>,
+      required: false,
+    },
+  },
+  setup(props) {
+    const handleClick = () => {
+      if (props.onSubmit) {
+        props.onSubmit();
+      }
+    };
+
+    return () => h('div', { 
+      style: { marginTop: '24px', textAlign: 'right' }
+    }, [
+      h('button', {
+        type: 'button',
+        onClick: handleClick,
+        'data-test-id': 'submit-button',
+        style: {
+          padding: '12px 24px',
+          backgroundColor: '#007bff',
+          color: 'white',
+          border: 'none',
+          borderRadius: '4px',
+          cursor: 'pointer',
+          fontSize: '16px',
+          fontWeight: '500',
+        }
+      }, 'Submit')
+    ]);
+  }
+});

--- a/packages/factories/vue/src/components/index.ts
+++ b/packages/factories/vue/src/components/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Vue Factory Components
+ * 
+ * Built-in components for the Vue form factory.
+ */
+
+export * from './DefaultFormContainer';
+export * from './DefaultSubmitButton';

--- a/packages/factories/vue/src/index.ts
+++ b/packages/factories/vue/src/index.ts
@@ -1,2 +1,22 @@
-export * from './form-factory';
+/**
+ * @schepta/factory-vue
+ * 
+ * Vue factories for schepta rendering engine
+ */
+
+// Main factory
+export {
+  createFormFactory,
+  type FormFactoryProps,
+  type FormFactoryRef,
+} from './form-factory';
+
+// Components (types and defaults)
+export {
+  DefaultFormContainer,
+  DefaultSubmitButton,
+  type FormContainerProps,
+  type SubmitButtonProps,
+  type SubmitButtonComponentType,
+} from './components';
 


### PR DESCRIPTION
… and Vanilla

- core: replace defaultComponentRegistry with factoryDefaultComponents (setFactoryDefaultComponents)
- core: FormContainer renderer preserves onSubmit and externalContext (no longer stripped by sanitizePropsForDOM)
- React: add DefaultFormContainer, DefaultSubmitButton in factory; FormFactory registers them via setFactoryDefaultComponents; submit button rendered inside form
- Vue: same DefaultFormContainer/DefaultSubmitButton and factory integration
- Vanilla: createDefaultFormContainer, createDefaultSubmitButton and factory integration
- examples: update FormContainer and SubmitButton in basic-ui, chakra-ui, material-ui; FormModal